### PR TITLE
Enable LAN access

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@
 LEON_LANG=en-US
 
 # Server
+# Use your local IP here to access Leon from other devices
 LEON_HOST=http://localhost
 LEON_PORT=1337
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ leon check
 # Run
 leon start
 
-# Go to http://localhost:1337
+# Go to http://localhost:1337 (or http://<local_ip>:1337 from another device)
 # Hooray! Leon is running
 ```
 

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -20,7 +20,8 @@ export default defineConfig({
     emptyOutDir: true
   },
   server: {
-    port: 3000
+    port: 3000,
+    host: true
   },
   plugins: [react()]
 })

--- a/hotword/README.md
+++ b/hotword/README.md
@@ -20,7 +20,7 @@ npm run setup:offline-hotword
 # Run main server
 npm run build && npm start
 
-# Go to http://localhost:1337
+# Go to http://localhost:1337 (or http://<local_ip>:1337 from another device)
 
 # Run hotword node
 npm run wake

--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import fs from 'node:fs'
+import { NetworkHelper } from '@/helpers/network-helper'
 
 import dotenv from 'dotenv'
 
@@ -202,7 +203,8 @@ export const FR_SPACY_MODEL_VERSION = '3.4.0'
  */
 export const LANG = process.env['LEON_LANG'] as LongLanguageCode
 
-export const HOST = process.env['LEON_HOST']
+const DEFAULT_IP = NetworkHelper.getLocalExternalIP() || 'localhost'
+export const HOST = process.env['LEON_HOST'] || `http://${DEFAULT_IP}`
 export const PORT = Number(process.env['LEON_PORT'])
 
 export const TIME_ZONE = process.env['LEON_TIME_ZONE']

--- a/server/src/core/socket-server.ts
+++ b/server/src/core/socket-server.ts
@@ -61,7 +61,7 @@ export default class SocketServer {
   public async init(): Promise<void> {
     const io = IS_DEVELOPMENT_ENV
       ? new SocketIOServer(HTTP_SERVER.httpServer, {
-          cors: { origin: `${HTTP_SERVER.host}:3000` }
+          cors: { origin: '*' }
         })
       : new SocketIOServer(HTTP_SERVER.httpServer)
 

--- a/server/src/helpers/network-helper.ts
+++ b/server/src/helpers/network-helper.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import os from 'node:os'
 
 const HUGGING_FACE_URL = 'https://huggingface.co'
 const HUGGING_FACE_MIRROR_URL = 'https://hf-mirror.com'
@@ -32,5 +33,23 @@ export class NetworkHelper {
     }
 
     return url
+  }
+
+  /**
+   * Get the first non-internal IPv4 address
+   * @example getLocalExternalIP() // '192.168.1.10'
+   */
+  public static getLocalExternalIP(): string | null {
+    const nets = os.networkInterfaces()
+
+    for (const name of Object.keys(nets)) {
+      for (const net of nets[name] || []) {
+        if (net.family === 'IPv4' && !net.internal) {
+          return net.address
+        }
+      }
+    }
+
+    return null
   }
 }


### PR DESCRIPTION
## Summary
- allow Vite dev server to listen on all interfaces
- return local IP if `LEON_HOST` is not set
- relax socket server CORS for dev mode
- document LAN usage in README files
- hint about editing `LEON_HOST` in env sample

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841340fa16083328b21846103b2481f