### PR TITLE
Add file parser skill and offline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ If you want to, Leon can communicate with you by being **offline to protect your
 > You can find what he is able to do by browsing the [skills list](https://github.com/leon-ai/leon/tree/develop/skills).<br>
 > Please do know that after the official release, we will build many skills along with the community. Feel free to [join us on Discord](https://discord.gg/MNQqqKg) to be part of the journey.
 
+The repository now includes a `file_parser` skill that works offline and can read
+formats such as **.xmind**, **.pdf**, **.docx**, **.txt**, **.xlsx**, **.eml**, **.mp4**, **.png** and **.jpg**.
+
 Sounds good to you? Then let's get started!
 
 ## ☁️ Try with a Single-Click
@@ -154,6 +157,19 @@ leon start
 # Go to http://localhost:1337
 # Hooray! Leon is running
 ```
+
+### Offline Setup on macOS (Apple&nbsp;Silicon)
+
+Leon can run completely offline once the speech engines and wake word models are
+installed locally. On a MacBook&nbsp;Air M2 run:
+
+```sh
+npm run setup:offline
+```
+
+This downloads the required STT, TTS and hotword packages and configures them
+for offline use.
+
 
 ## 📚 Documentation
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,18 @@
+# Skills Directory
+
+Skills are modular features that extend Leon's abilities. Each skill lives in its own folder and can be developed and tested independently.
+
+```
+skills/
+  <category>/<skill-name>/
+    config/      # intents and answers
+    src/         # implementation
+    memory/      # optional persistent data
+    skill.json   # metadata
+```
+
+To create a new skill, copy an existing one and adjust the configuration. New skills can be shared with the community.
+
+## File Parser
+
+The `utilities/file_parser` skill demonstrates how a skill can handle a variety of file formats offline. See its [README](utilities/file_parser/README.md) for details.

--- a/skills/utilities/file_parser/README.md
+++ b/skills/utilities/file_parser/README.md
@@ -1,0 +1,28 @@
+# File Parser Skill
+
+This skill extracts basic information from a variety of common file types. It works entirely offline once the required Python packages are installed.
+
+## Supported Formats
+
+- `.xmind`
+- `.pdf`
+- `.docx`
+- `.txt`
+- `.xlsx`
+- `.eml`
+- `.mp4`
+- `.png`, `.jpg`
+
+## Dependencies
+
+Install the following packages inside your Python environment:
+
+```sh
+pip install PyPDF2 python-docx openpyxl xmindparser Pillow
+```
+
+`ffprobe` from FFmpeg is also required for MP4 metadata extraction.
+
+## Usage
+
+Invoke the `analyze` action with the path to a file. Leon will respond with a short summary or metadata extracted from the file.

--- a/skills/utilities/file_parser/config/en.json
+++ b/skills/utilities/file_parser/config/en.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../../../schemas/skill-schemas/skill-config.json",
+  "actions": {
+    "analyze": {
+      "type": "logic",
+      "utterance_samples": [
+        "Analyze file @file",
+        "Read @file",
+        "Open @file",
+        "Get info about @file"
+      ],
+      "http_api": {
+        "entities": [
+          { "entity": "file", "resolution": ["value"] }
+        ]
+      }
+    }
+  },
+  "answers": {
+    "summary": [
+      "Here is the information for %file%: %info%"
+    ],
+    "unsupported": [
+      "Unsupported file type for %file%."
+    ],
+    "not_found": [
+      "I cannot find %file%."
+    ]
+  }
+}

--- a/skills/utilities/file_parser/skill.json
+++ b/skills/utilities/file_parser/skill.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../schemas/skill-schemas/skill.json",
+  "name": "File Parser",
+  "bridge": "python",
+  "version": "1.0.0",
+  "description": "Extracts basic information from various file types.",
+  "author": {
+    "name": "Codex",
+    "url": "https://github.com"
+  }
+}

--- a/skills/utilities/file_parser/src/actions/analyze.py
+++ b/skills/utilities/file_parser/src/actions/analyze.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+import subprocess
+import json
+
+from bridges.python.src.sdk.leon import leon
+from bridges.python.src.sdk.types import ActionParams
+
+try:
+    import PyPDF2
+except ImportError:
+    PyPDF2 = None
+
+try:
+    import docx
+except ImportError:
+    docx = None
+
+try:
+    import openpyxl
+except ImportError:
+    openpyxl = None
+
+try:
+    import xmindparser
+except ImportError:
+    xmindparser = None
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+
+def read_txt(path: Path) -> str:
+    return path.read_text(errors='ignore')[:200]
+
+
+def read_pdf(path: Path) -> str:
+    if PyPDF2 is None:
+        return 'PyPDF2 not installed'
+    text = ''
+    with open(path, 'rb') as f:
+        reader = PyPDF2.PdfReader(f)
+        for page in reader.pages[:5]:
+            text += page.extract_text() or ''
+    return text[:200]
+
+
+def read_docx(path: Path) -> str:
+    if docx is None:
+        return 'python-docx not installed'
+    doc = docx.Document(path)
+    text = '\n'.join(p.text for p in doc.paragraphs)
+    return text[:200]
+
+
+def read_xlsx(path: Path) -> str:
+    if openpyxl is None:
+        return 'openpyxl not installed'
+    wb = openpyxl.load_workbook(path, read_only=True)
+    ws = wb.active
+    rows = []
+    for row in ws.iter_rows(max_row=5, values_only=True):
+        rows.append(', '.join(str(c) for c in row))
+    return '\n'.join(rows)
+
+
+def read_eml(path: Path) -> str:
+    import email
+    from email import policy
+    with open(path, 'rb') as f:
+        msg = email.message_from_binary_file(f, policy=policy.default)
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == 'text/plain':
+                return part.get_payload(decode=True).decode(errors='ignore')[:200]
+    else:
+        return msg.get_payload(decode=True).decode(errors='ignore')[:200]
+    return ''
+
+
+def read_mp4(path: Path) -> str:
+    result = subprocess.run([
+        'ffprobe', '-v', 'quiet', '-print_format', 'json', '-show_format',
+        '-show_streams', str(path)
+    ], capture_output=True)
+    if result.returncode != 0:
+        return 'ffprobe error'
+    info = json.loads(result.stdout or '{}')
+    duration = info.get('format', {}).get('duration')
+    return f'duration: {duration}s'
+
+
+def read_image(path: Path) -> str:
+    if Image is None:
+        return 'Pillow not installed'
+    with Image.open(path) as img:
+        return f'resolution: {img.width}x{img.height}'
+
+
+def run(params: ActionParams) -> None:
+    file_path = params.current_entities[0]['resolution']['value'] if params.current_entities else None
+    if not file_path:
+        leon.answer({'key': 'not_found', 'data': {'file': ''}})
+        return
+    path = Path(file_path)
+    if not path.exists():
+        leon.answer({'key': 'not_found', 'data': {'file': file_path}})
+        return
+
+    ext = path.suffix.lower()
+    info = ''
+    if ext == '.txt':
+        info = read_txt(path)
+    elif ext == '.pdf':
+        info = read_pdf(path)
+    elif ext == '.docx':
+        info = read_docx(path)
+    elif ext == '.xlsx':
+        info = read_xlsx(path)
+    elif ext == '.eml':
+        info = read_eml(path)
+    elif ext == '.mp4':
+        info = read_mp4(path)
+    elif ext in ['.png', '.jpg', '.jpeg']:
+        info = read_image(path)
+    elif ext == '.xmind':
+        if xmindparser is None:
+            info = 'xmindparser not installed'
+        else:
+            data = xmindparser.xmind_to_dict(str(path))
+            info = json.dumps(data)[:200]
+    else:
+        leon.answer({'key': 'unsupported', 'data': {'file': file_path}})
+        return
+
+    leon.answer({'key': 'summary', 'data': {'file': file_path, 'info': info}})


### PR DESCRIPTION
## Summary
- add new `file_parser` skill for parsing common file formats offline
- document skills layout in `skills/README.md`
- mention `file_parser` skill and offline setup for macOS in main README

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: unsupported engine)*

------
https://chatgpt.com/codex/tasks/task_e_6841345b7bb08332aaa0ad21a9319485