### PR TITLE
Add XMind indexing and Q/A

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,11 @@
     "socket.io": "4.7.5",
     "socket.io-client": "4.7.5",
     "stt": "1.4.0",
-    "tree-kill": "1.2.2"
+    "tree-kill": "1.2.2",
+    "chromadb": "3.0.1",
+    "jszip": "3.10.1",
+    "xml2js": "0.6.2",
+    "xmind": "2.2.33"
   },
   "devDependencies": {
     "@eslint/compat": "1.2.3",

--- a/server/src/mindmaps/xmind-index.ts
+++ b/server/src/mindmaps/xmind-index.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import JSZip from 'jszip'
+import { parseStringPromise } from 'xml2js'
+import { ChromaClient } from 'chromadb'
+
+import { LogHelper } from '@/helpers/log-helper'
+import { CustomLLMDuty } from '@/core/llm-manager/llm-duties/custom-llm-duty'
+
+export interface MindMapNode {
+  id: string
+  title: string
+  notes?: string
+  children: MindMapNode[]
+  summary?: string
+  tags?: string[]
+}
+
+export class XMindIndexer {
+  private chroma = new ChromaClient({})
+  private collectionName: string
+  private collection: Awaited<ReturnType<ChromaClient['getOrCreateCollection']>> | null = null
+
+  constructor(collectionName = 'xmind') {
+    this.collectionName = collectionName
+  }
+
+  private async ensureCollection(): Promise<void> {
+    if (!this.collection) {
+      this.collection = await this.chroma.getOrCreateCollection({
+        name: this.collectionName
+      })
+    }
+  }
+
+  private parseTopic(xml: any): MindMapNode {
+    const id = xml.$.id as string
+    const title = Array.isArray(xml.title) ? xml.title[0] : ''
+    const notes = xml.notes?.[0]?.plain?.[0] ?? ''
+
+    const node: MindMapNode = { id, title, notes, children: [] }
+
+    const childrenBlocks = xml.children?.[0]?.topics || []
+    for (const block of childrenBlocks) {
+      const topics = block.topic || []
+      for (const child of topics) {
+        node.children.push(this.parseTopic(child))
+      }
+    }
+
+    return node
+  }
+
+  public async load(filePath: string): Promise<MindMapNode[]> {
+    const buffer = await fs.promises.readFile(path.resolve(filePath))
+    const zip = await JSZip.loadAsync(buffer)
+    let content: string | null = null
+    if (zip.files['content.json']) {
+      content = await zip.files['content.json'].async('string')
+      const json = JSON.parse(content)
+      const sheets = json.sheets || []
+      return sheets.map((s: any) => this.parseTopic(s.rootTopic))
+    }
+
+    if (zip.files['content.xml']) {
+      content = await zip.files['content.xml'].async('string')
+      const parsed = await parseStringPromise(content)
+      const sheets = parsed['xmap-content'].sheet || []
+      return sheets.map((s: any) => this.parseTopic(s.topic[0]))
+    }
+
+    throw new Error('Invalid XMind file')
+  }
+
+  private async summarizeNode(node: MindMapNode): Promise<void> {
+    const duty = new CustomLLMDuty({
+      input: `${node.title}\n${node.notes || ''}\nSummarize and provide tags as comma separated list`,
+      data: { systemPrompt: 'You are a helpful assistant that summarizes mind map nodes and extracts tags.' }
+    })
+    await duty.init()
+    const result = await duty.execute()
+    if (result) {
+      const out = String(result.output)
+      const [summary, tags] = out.split('\n')
+      node.summary = summary.trim()
+      node.tags = (tags || '').split(',').map(t => t.trim()).filter(Boolean)
+    }
+
+    for (const child of node.children) {
+      await this.summarizeNode(child)
+    }
+  }
+
+  private flatten(node: MindMapNode, acc: MindMapNode[] = []): MindMapNode[] {
+    acc.push(node)
+    for (const child of node.children) {
+      this.flatten(child, acc)
+    }
+    return acc
+  }
+
+  public async index(nodes: MindMapNode[]): Promise<void> {
+    await this.ensureCollection()
+
+    for (const node of nodes) {
+      await this.summarizeNode(node)
+      const flat = this.flatten(node)
+      for (const item of flat) {
+        const doc = `${item.title}\n${item.notes || ''}\n${item.summary || ''}`
+        await this.collection?.add({
+          ids: [item.id],
+          documents: [doc]
+        })
+      }
+    }
+  }
+
+  public async answer(question: string): Promise<string | null> {
+    await this.ensureCollection()
+    const res = await this.collection?.query({ queryTexts: [question], nResults: 3 })
+    const docs = res?.documents?.[0] || []
+    const context = docs.join('\n')
+    const duty = new CustomLLMDuty({
+      input: `Context:\n${context}\n\nQuestion: ${question}`,
+      data: { systemPrompt: 'Answer the question based on the context.' }
+    })
+    await duty.init()
+    const result = await duty.execute()
+    return result ? String(result.output) : null
+  }
+}


### PR DESCRIPTION
## Summary
- integrate packages for XMind parsing and ChromaDB
- implement `XMindIndexer` to parse .xmind files, summarize nodes with LLM and store them into ChromaDB

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841346e63a883328c7bad1b40ef9e67