### PR TITLE
Add preliminary autonomous agent module

### DIFF
--- a/server/src/constants.ts
+++ b/server/src/constants.ts
@@ -32,6 +32,7 @@ export const IS_TESTING_ENV = LEON_NODE_ENV === TESTING_ENV
  */
 export const BIN_PATH = path.join(process.cwd(), 'bin')
 export const LOGS_PATH = path.join(process.cwd(), 'logs')
+export const AGENT_MEMORY_PATH = path.join(LOGS_PATH, "agent_memory.json")
 export const SKILLS_PATH = path.join(process.cwd(), 'skills')
 export const GLOBAL_DATA_PATH = path.join(process.cwd(), 'core', 'data')
 export const MODELS_PATH = path.join(GLOBAL_DATA_PATH, 'models')

--- a/server/src/core/agent/agent.ts
+++ b/server/src/core/agent/agent.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs'
+
+import { LogHelper } from '@/helpers/log-helper'
+import { CustomLLMDuty } from '@/core/llm-manager/llm-duties/custom-llm-duty'
+import { AGENT_MEMORY_PATH } from '@/constants'
+
+export interface AgentStep {
+  task: string
+  tool?: string
+}
+
+export default class Agent {
+  private readonly memoryPath = AGENT_MEMORY_PATH
+
+  constructor() {
+    LogHelper.title('Agent')
+    LogHelper.success('New instance')
+
+    if (!fs.existsSync(this.memoryPath)) {
+      fs.writeFileSync(this.memoryPath, '[]', 'utf-8')
+    }
+  }
+
+  private async loadMemory(): Promise<AgentStep[]> {
+    try {
+      const raw = await fs.promises.readFile(this.memoryPath, 'utf-8')
+      return JSON.parse(raw) as AgentStep[]
+    } catch (e) {
+      LogHelper.error(`Failed to load agent memory: ${e}`)
+    }
+
+    return []
+  }
+
+  private async saveMemory(history: AgentStep[]): Promise<void> {
+    try {
+      await fs.promises.writeFile(
+        this.memoryPath,
+        JSON.stringify(history, null, 2),
+        'utf-8'
+      )
+    } catch (e) {
+      LogHelper.error(`Failed to save agent memory: ${e}`)
+    }
+  }
+
+  private async addMemory(step: AgentStep): Promise<void> {
+    const history = await this.loadMemory()
+    history.push(step)
+    await this.saveMemory(history)
+  }
+
+  public async plan(goal: string): Promise<AgentStep[]> {
+    const duty = new CustomLLMDuty({
+      input: `Break the following goal into steps in JSON array format: ${goal}`,
+      data: { systemPrompt: 'You are a helpful planner that returns JSON.' }
+    })
+    await duty.init()
+    const result = await duty.execute()
+
+    try {
+      const steps = JSON.parse(result?.output as unknown as string) as AgentStep[]
+      return steps
+    } catch (e) {
+      LogHelper.error(`Failed to parse plan result: ${e}`)
+    }
+
+    return []
+  }
+
+  public async run(goal: string): Promise<AgentStep[]> {
+    const plan = await this.plan(goal)
+    for (const step of plan) {
+      await this.addMemory(step)
+    }
+    return plan
+  }
+}

--- a/server/src/core/index.ts
+++ b/server/src/core/index.ts
@@ -20,6 +20,7 @@ import Brain from '@/core/brain/brain'
 import LLMManager from '@/core/llm-manager/llm-manager'
 import LLMProvider from '@/core/llm-manager/llm-provider'
 import Persona from '@/core/llm-manager/persona'
+import Agent from "@/core/agent/agent"
 import { ConversationLogger } from '@/conversation-logger'
 import { SystemHelper } from '@/helpers/system-helper'
 import { LogHelper } from '@/helpers/log-helper'
@@ -85,3 +86,5 @@ export const MODEL_LOADER = new ModelLoader()
 export const NLU = new NaturalLanguageUnderstanding()
 
 export const BRAIN = new Brain()
+
+export const AGENT = new Agent()


### PR DESCRIPTION
## Summary
- add constant `AGENT_MEMORY_PATH`
- implement new `Agent` class for multi-step planning
- expose agent in core index

## Testing
- `npm run lint` *(fails: tsx not found)*
- `npm install` *(fails: unsupported Node engine)*

------
https://chatgpt.com/codex/tasks/task_e_684134c15aec83328ad6b2a5baa211da