### PR TITLE
Add email analysis skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ If you want to, Leon can communicate with you by being **offline to protect your
 The repository now includes a `file_parser` skill that works offline and can read
 formats such as **.xmind**, **.pdf**, **.docx**, **.txt**, **.xlsx**, **.eml**, **.mp4**, **.png** and **.jpg**.
 
+### Current Features
+
+- Offline file parser for PDFs, DOCX, XLSX, TXT, EML and more.
+- Mind map tagging and search.
+- Email analysis with Thunderbird mailbox support and reply drafting.
+- Speech transcription via Whisper and OCR with Tesseract.
+- **Voice command hotword detection is still planned.**
+
 Sounds good to you? Then let's get started!
 
 ## ☁️ Try with a Single-Click

--- a/functionality.md
+++ b/functionality.md
@@ -1,6 +1,8 @@
 # 🧠 Leon Autonomous AI Assistant – Functionalities & Use Cases
 
 This document outlines the full capabilities of the upgraded **Leon AI system**, now acting as a **fully offline, multi-step autonomous agent** for productivity, document intelligence, and AI-powered task execution.
+Features marked with **(planned)** are not yet implemented.
+
 
 ---
 
@@ -44,7 +46,7 @@ This document outlines the full capabilities of the upgraded **Leon AI system**,
 | ----------------------- | ------------------- | ------------------------------------------------------ |
 | **Audio Transcription** | Whisper integration | Transcribes `.mp3` or `.mp4` meeting recordings        |
 | **OCR**                 | Tesseract           | Extracts text from images, scans, or handwritten notes |
-| **Voice Commands**      | (Optional skill)    | Say “Hey Leon” + goal via mic (planned feature)        |
+| **Voice Commands (planned)** | (Optional skill) | Say “Hey Leon” + goal via mic |
 
 ---
 

--- a/skills/productivity/email/config/en.json
+++ b/skills/productivity/email/config/en.json
@@ -7,10 +7,18 @@
         "Summarize emails",
         "Check my inbox"
       ]
+    },
+    "draft_reply": {
+      "type": "logic",
+      "utterance_samples": [
+        "Draft a reply",
+        "Write a response"
+      ]
     }
   },
   "answers": {
-    "done": ["Emails processed."],
+    "summary": ["%summary%"],
+    "reply": ["%reply%"],
     "error": ["Unable to process emails."]
   }
 }

--- a/skills/productivity/email/src/actions/draft_reply.py
+++ b/skills/productivity/email/src/actions/draft_reply.py
@@ -1,0 +1,57 @@
+import mailbox
+import os
+import requests
+from email import policy
+from email.parser import BytesParser
+
+from bridges.python.src.sdk.leon import leon
+from bridges.python.src.sdk.types import ActionParams
+
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL", "mistral")
+
+
+def extract_latest(path: str) -> str:
+    """Return text of the latest email in an mbox or single .eml file."""
+    if path.endswith(".eml"):
+        with open(path, "rb") as f:
+            msg = BytesParser(policy=policy.default).parse(f)
+        payload = msg.get_body(preferencelist=("plain",))
+        if payload:
+            return payload.get_content()
+        return msg.get_payload(decode=True).decode(errors="ignore")
+    mbox = mailbox.mbox(path)
+    if len(mbox) == 0:
+        return ""
+    msg = mbox[-1]
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                return part.get_payload(decode=True).decode(errors="ignore")
+    return msg.get_payload(decode=True).decode(errors="ignore")
+
+
+def run(params: ActionParams) -> None:
+    """Draft a reply for the latest email."""
+    path = None
+    for ent in params["entities"]:
+        if ent["entity"] == "path":
+            path = ent["resolution"]["value"]
+            break
+    if path is None:
+        return leon.answer({"key": "error"})
+
+    try:
+        content = extract_latest(path)
+        prompt = f"Write a short and polite reply to the following email:\n{content}"
+        resp = requests.post(
+            "http://localhost:11434/api/generate",
+            json={"model": OLLAMA_MODEL, "prompt": prompt, "stream": False},
+            timeout=20,
+        )
+        if resp.ok:
+            reply = resp.json().get("response", "").strip()
+            leon.answer({"key": "reply", "data": {"reply": reply}})
+        else:
+            leon.answer({"key": "error"})
+    except Exception:
+        leon.answer({"key": "error"})

--- a/skills/productivity/email/src/actions/run.py
+++ b/skills/productivity/email/src/actions/run.py
@@ -4,13 +4,36 @@ from bridges.python.src.sdk.types import ActionParams
 import os
 import mailbox
 import email
+from email import policy
 import requests
 
 OLLAMA_MODEL = os.getenv('OLLAMA_MODEL', 'mistral')
 
 
+def extract_bodies(path: str) -> list[str]:
+    messages = []
+    if path.endswith('.eml'):
+        with open(path, 'rb') as f:
+            msg = email.message_from_binary_file(f, policy=policy.default)
+            messages.append(msg)
+    else:
+        mbox = mailbox.mbox(path)
+        for msg in mbox:
+            messages.append(msg)
+    bodies: list[str] = []
+    for msg in messages[-5:]:
+        if msg.is_multipart():
+            for part in msg.walk():
+                if part.get_content_type() == 'text/plain':
+                    bodies.append(part.get_payload(decode=True).decode(errors='ignore'))
+                    break
+        else:
+            bodies.append(msg.get_payload(decode=True).decode(errors='ignore'))
+    return bodies
+
+
 def run(params: ActionParams) -> None:
-    """Parse emails and summarize threads"""
+    """Parse emails and summarize threads."""
     path = None
     for ent in params['entities']:
         if ent['entity'] == 'path':
@@ -20,8 +43,17 @@ def run(params: ActionParams) -> None:
         return leon.answer({'key': 'error'})
 
     try:
-        mbox = mailbox.mbox(path)
-        subjects = [msg['subject'] for msg in mbox]
-        leon.answer({'key': 'done'})
+        bodies = extract_bodies(path)
+        prompt = 'Summarize the following emails:\n' + '\n\n'.join(bodies)
+        resp = requests.post(
+            'http://localhost:11434/api/generate',
+            json={'model': OLLAMA_MODEL, 'prompt': prompt, 'stream': False},
+            timeout=20
+        )
+        if resp.ok:
+            summary = resp.json().get('response', '').strip()
+            leon.answer({'key': 'summary', 'data': {'summary': summary}})
+        else:
+            leon.answer({'key': 'error'})
     except Exception:
         leon.answer({'key': 'error'})


### PR DESCRIPTION
## Summary
- add skill for Thunderbird email parsing and reply drafting
- expose new `draft_reply` action
- document current features in README
- clarify planned feature in docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841373dfa848332b4d867449f1180ce